### PR TITLE
Replace tmux with kitty for dev workflow

### DIFF
--- a/aliases.zsh
+++ b/aliases.zsh
@@ -3,9 +3,5 @@ alias d='dirs -v'
 
 for index ({1..9}) alias "$index"="cd +${index}"; unset index
 
-# tmux
-alias tl='tmux list-sessions'
-alias ta='tmux attach -t'
-alias tk='tmux kill-session -t'
 alias tn='dev ~/Documents/notes notes'
 

--- a/dot_config/kitty/kitty.conf
+++ b/dot_config/kitty/kitty.conf
@@ -173,4 +173,4 @@ map cmd+shift+s    show_scrollback
 scrollback_pager nvim -c "set nolist showtabline=0" -c "normal G" -
 
 # Hints (select URLs, paths, hashes from terminal output)
-map cmd+shift+h    kitten hints --type url --program default
+map cmd+shift+h    kitten hints --type url --program open

--- a/dot_config/kitty/kitty.conf
+++ b/dot_config/kitty/kitty.conf
@@ -165,5 +165,12 @@ map cmd+minus  change_font_size all -1.0
 map cmd+0      change_font_size all 0
 
 # Scrollback
-map cmd+k scroll_page_up
-map shift+cmd+k clear_terminal scroll active
+map cmd+k          scroll_page_up
+map shift+cmd+k    clear_terminal scroll active
+map cmd+shift+s    show_scrollback
+
+# Scrollback pager: open in nvim, jump to bottom
+scrollback_pager nvim -c "set nolist showtabline=0" -c "normal G" -
+
+# Hints (select URLs, paths, hashes from terminal output)
+map cmd+shift+h    kitten hints

--- a/dot_config/kitty/kitty.conf
+++ b/dot_config/kitty/kitty.conf
@@ -173,4 +173,4 @@ map cmd+shift+s    show_scrollback
 scrollback_pager nvim -c "set nolist showtabline=0" -c "normal G" -
 
 # Hints (select URLs, paths, hashes from terminal output)
-map cmd+shift+h    kitten hints
+map cmd+shift+h    kitten hints --type url --program default

--- a/dot_config/kitty/kitty.conf
+++ b/dot_config/kitty/kitty.conf
@@ -1,6 +1,17 @@
 term xterm-256color
 
 # =============================================================================
+# Remote control (used by dev script for layout management)
+# =============================================================================
+allow_remote_control socket-only
+listen_on            unix:/tmp/kitty-{kitty_pid}
+
+# =============================================================================
+# Layouts
+# =============================================================================
+enabled_layouts splits,stack
+
+# =============================================================================
 # Font
 # =============================================================================
 font_family      Hack
@@ -122,12 +133,31 @@ map cmd+2  goto_tab 2
 map cmd+3  goto_tab 3
 map cmd+4  goto_tab 4
 map cmd+5  goto_tab 5
+map cmd+6  goto_tab 6
+map cmd+7  goto_tab 7
+map cmd+8  goto_tab 8
+map cmd+9  goto_tab 9
 
 # Windows / splits
 map cmd+d       launch --location=vsplit --cwd=current
 map cmd+shift+d launch --location=hsplit --cwd=current
 map cmd+shift+] next_window
 map cmd+shift+[ previous_window
+
+# Pane navigation (ctrl+h/j/k/l — matches neovim splits)
+map ctrl+h neighboring_window left
+map ctrl+j neighboring_window bottom
+map ctrl+k neighboring_window top
+map ctrl+l neighboring_window right
+
+# Pane resize
+map ctrl+shift+h resize_window narrower 3
+map ctrl+shift+j resize_window taller 3
+map ctrl+shift+k resize_window shorter 3
+map ctrl+shift+l resize_window wider 3
+
+# Stack/zoom toggle (like tmux prefix+z)
+map cmd+shift+z toggle_layout stack
 
 # Font size
 map cmd+equal  change_font_size all +1.0

--- a/dot_config/nvim/init.lua
+++ b/dot_config/nvim/init.lua
@@ -51,23 +51,23 @@ vim.g.netrw_banner = 0
 vim.g.netrw_liststyle = 3
 vim.g.netrw_winsize = 25
 
--- ── Tmux-aware navigation ────────────────────────────────────────────
-local function tmux_navigate(direction)
+-- ── Kitty-aware navigation ───────────────────────────────────────────
+local function kitty_navigate(direction)
   local win = vim.api.nvim_get_current_win()
   vim.cmd("wincmd " .. direction)
   if vim.api.nvim_get_current_win() == win then
-    local tmux_dir = ({ h = "L", j = "D", k = "U", l = "R" })[direction]
-    vim.fn.system({ "tmux", "select-pane", "-" .. tmux_dir })
+    local kitty_dir = ({ h = "left", j = "bottom", k = "top", l = "right" })[direction]
+    vim.fn.system({ "kitty", "@", "focus-window", "--match", "neighbor:" .. kitty_dir })
   end
 end
 
 local map = vim.keymap.set
 
--- Window/tmux navigation
-map("n", "<C-h>", function() tmux_navigate("h") end, { desc = "Navigate left" })
-map("n", "<C-j>", function() tmux_navigate("j") end, { desc = "Navigate down" })
-map("n", "<C-k>", function() tmux_navigate("k") end, { desc = "Navigate up" })
-map("n", "<C-l>", function() tmux_navigate("l") end, { desc = "Navigate right" })
+-- Window/kitty navigation
+map("n", "<C-h>", function() kitty_navigate("h") end, { desc = "Navigate left" })
+map("n", "<C-j>", function() kitty_navigate("j") end, { desc = "Navigate down" })
+map("n", "<C-k>", function() kitty_navigate("k") end, { desc = "Navigate up" })
+map("n", "<C-l>", function() kitty_navigate("l") end, { desc = "Navigate right" })
 
 -- ── Keymaps ──────────────────────────────────────────────────────────
 
@@ -536,11 +536,9 @@ vim.api.nvim_create_autocmd({ "TextChanged", "TextChangedI" }, {
 })
 
 -- ── RPC server for external tools (lola, cursor, etc.) ───────────────
-local tmux_session = vim.fn.getenv("TMUX") ~= vim.NIL
-  and vim.trim(vim.fn.system("tmux display-message -p '#S'"))
-  or nil
-if tmux_session and tmux_session ~= "" then
-  vim.fn.serverstart("/tmp/nvim-" .. tmux_session .. ".sock")
+local kitty_pid = vim.fn.getenv("KITTY_PID")
+if kitty_pid ~= vim.NIL and kitty_pid ~= "" then
+  vim.fn.serverstart("/tmp/nvim-kitty-" .. kitty_pid .. ".sock")
 end
 
 -- ── Colorscheme ──────────────────────────────────────────────────────

--- a/dot_config/nvim/init.lua
+++ b/dot_config/nvim/init.lua
@@ -51,23 +51,13 @@ vim.g.netrw_banner = 0
 vim.g.netrw_liststyle = 3
 vim.g.netrw_winsize = 25
 
--- ── Kitty-aware navigation ───────────────────────────────────────────
-local function kitty_navigate(direction)
-  local win = vim.api.nvim_get_current_win()
-  vim.cmd("wincmd " .. direction)
-  if vim.api.nvim_get_current_win() == win then
-    local kitty_dir = ({ h = "left", j = "bottom", k = "top", l = "right" })[direction]
-    vim.fn.system({ "kitty", "@", "focus-window", "--match", "neighbor:" .. kitty_dir })
-  end
-end
-
 local map = vim.keymap.set
 
--- Window/kitty navigation
-map("n", "<C-h>", function() kitty_navigate("h") end, { desc = "Navigate left" })
-map("n", "<C-j>", function() kitty_navigate("j") end, { desc = "Navigate down" })
-map("n", "<C-k>", function() kitty_navigate("k") end, { desc = "Navigate up" })
-map("n", "<C-l>", function() kitty_navigate("l") end, { desc = "Navigate right" })
+-- Window navigation
+map("n", "<C-h>", "<C-w>h", { desc = "Navigate left" })
+map("n", "<C-j>", "<C-w>j", { desc = "Navigate down" })
+map("n", "<C-k>", "<C-w>k", { desc = "Navigate up" })
+map("n", "<C-l>", "<C-w>l", { desc = "Navigate right" })
 
 -- ── Keymaps ──────────────────────────────────────────────────────────
 

--- a/dot_config/nvim/init.lua
+++ b/dot_config/nvim/init.lua
@@ -53,11 +53,20 @@ vim.g.netrw_winsize = 25
 
 local map = vim.keymap.set
 
--- Window navigation
-map("n", "<C-h>", "<C-w>h", { desc = "Navigate left" })
-map("n", "<C-j>", "<C-w>j", { desc = "Navigate down" })
-map("n", "<C-k>", "<C-w>k", { desc = "Navigate up" })
-map("n", "<C-l>", "<C-w>l", { desc = "Navigate right" })
+-- Window/kitty navigation
+local function kitty_navigate(direction)
+  local win = vim.api.nvim_get_current_win()
+  vim.cmd("wincmd " .. direction)
+  if vim.api.nvim_get_current_win() == win then
+    local kitty_dir = ({ h = "left", j = "bottom", k = "top", l = "right" })[direction]
+    vim.fn.system({ "kitty", "@", "focus-window", "--match", "neighbor:" .. kitty_dir })
+  end
+end
+
+map("n", "<C-h>", function() kitty_navigate("h") end, { desc = "Navigate left" })
+map("n", "<C-j>", function() kitty_navigate("j") end, { desc = "Navigate down" })
+map("n", "<C-k>", function() kitty_navigate("k") end, { desc = "Navigate up" })
+map("n", "<C-l>", function() kitty_navigate("l") end, { desc = "Navigate right" })
 
 -- ── Keymaps ──────────────────────────────────────────────────────────
 

--- a/dot_config/nvim/init.lua
+++ b/dot_config/nvim/init.lua
@@ -538,7 +538,7 @@ vim.api.nvim_create_autocmd({ "TextChanged", "TextChangedI" }, {
 -- ── RPC server for external tools (lola, cursor, etc.) ───────────────
 local kitty_pid = vim.fn.getenv("KITTY_PID")
 if kitty_pid ~= vim.NIL and kitty_pid ~= "" then
-  vim.fn.serverstart("/tmp/nvim-kitty-" .. kitty_pid .. ".sock")
+  pcall(vim.fn.serverstart, "/tmp/nvim-kitty-" .. kitty_pid .. ".sock")
 end
 
 -- ── Colorscheme ──────────────────────────────────────────────────────

--- a/dot_local/bin/executable_dev.tmpl
+++ b/dot_local/bin/executable_dev.tmpl
@@ -10,5 +10,4 @@ if [ -z "$KITTY_LISTEN_ON" ]; then
   exit 1
 fi
 
-kitty @ launch --type=tab --tab-title "$TITLE" --cwd "$DIR" > /dev/null
 kitty @ launch --type=tab --tab-title "$TITLE: claude" --cwd "$DIR" {{ if eq .machine "work" }}cursor-agent{{ else }}claude{{ end }} > /dev/null

--- a/dot_local/bin/executable_dev.tmpl
+++ b/dot_local/bin/executable_dev.tmpl
@@ -1,30 +1,14 @@
 #!/usr/bin/env bash
-# dev — open a kitty dev layout in a new tab
-# Usage: dev [directory] [session-name]
-#
-# Layout:
-#   +------------------+----------+
-#   |                  |          |
-#   |     Neovim       |  Claude  |
-#   +------------------+          |
-#   |    Terminal      |          |
-#   +------------------+----------+
+# dev — open a dev workspace in kitty (terminal tab + claude tab)
+# Usage: dev [directory]
 
 DIR="${1:-$(pwd)}"
-SESSION="${2:-$(basename "$DIR")}"
-TITLE="Dev [$SESSION]"
+TITLE="$(basename "$DIR")"
 
 if [ -z "$KITTY_LISTEN_ON" ]; then
   echo "Error: not running inside kitty (or remote control is not enabled)"
-  echo "Launch kitty first, then run dev from inside it."
   exit 1
 fi
 
-# Create new tab with neovim
-kitty @ launch --type=tab --tab-title "$TITLE" --cwd "$DIR" --title neovim nvim .
-
-# Right column: claude (full height)
-kitty @ launch --location=vsplit --dont-take-focus --cwd "$DIR" --title claude {{ if eq .machine "work" }}cursor-agent{{ else }}claude{{ end }}
-
-# Bottom-left: terminal
-kitty @ launch --location=hsplit --dont-take-focus --cwd "$DIR" --title terminal
+kitty @ launch --type=tab --tab-title "$TITLE" --cwd "$DIR"
+kitty @ launch --type=tab --tab-title "$TITLE: claude" --cwd "$DIR" {{ if eq .machine "work" }}cursor-agent{{ else }}claude{{ end }}

--- a/dot_local/bin/executable_dev.tmpl
+++ b/dot_local/bin/executable_dev.tmpl
@@ -10,5 +10,5 @@ if [ -z "$KITTY_LISTEN_ON" ]; then
   exit 1
 fi
 
-kitty @ launch --type=tab --tab-title "$TITLE" --cwd "$DIR"
-kitty @ launch --type=tab --tab-title "$TITLE: claude" --cwd "$DIR" {{ if eq .machine "work" }}cursor-agent{{ else }}claude{{ end }}
+kitty @ launch --type=tab --tab-title "$TITLE" --cwd "$DIR" > /dev/null
+kitty @ launch --type=tab --tab-title "$TITLE: claude" --cwd "$DIR" {{ if eq .machine "work" }}cursor-agent{{ else }}claude{{ end }} > /dev/null

--- a/dot_local/bin/executable_dev.tmpl
+++ b/dot_local/bin/executable_dev.tmpl
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# dev — start or attach to a tmux dev session
+# dev — open a kitty dev layout in a new tab
 # Usage: dev [directory] [session-name]
 #
 # Layout:
@@ -14,29 +14,17 @@ DIR="${1:-$(pwd)}"
 SESSION="${2:-$(basename "$DIR")}"
 TITLE="Dev [$SESSION]"
 
-if tmux has-session -t "$SESSION" 2>/dev/null; then
-  tmux rename-window -t "$SESSION:1" "$TITLE"
-  echo -ne '\033]0;'"$TITLE"'\007'
-  tmux attach -t "$SESSION"
-  exit
+if [ -z "$KITTY_LISTEN_ON" ]; then
+  echo "Error: not running inside kitty (or remote control is not enabled)"
+  echo "Launch kitty first, then run dev from inside it."
+  exit 1
 fi
 
-tmux new-session -d -s "$SESSION" -c "$DIR"
-tmux rename-window -t "$SESSION:1" "$TITLE"
+# Create new tab with neovim
+kitty @ launch --type=tab --tab-title "$TITLE" --cwd "$DIR" --title neovim nvim .
 
-# Right column: claude (full height, 35% width)
-tmux split-window -h -p 35 -t "$SESSION:1.1" -c "$DIR"
-tmux send-keys -t "$SESSION:1.2" "{{ if eq .machine "work" }}cursor-agent{{ else }}claude{{ end }}" Enter
+# Right column: claude (full height)
+kitty @ launch --location=vsplit --dont-take-focus --cwd "$DIR" --title claude {{ if eq .machine "work" }}cursor-agent{{ else }}claude{{ end }}
 
-# Left column: split for terminal at bottom (25% of left height)
-tmux select-pane -t "$SESSION:1.1"
-tmux split-window -v -p 20 -t "$SESSION:1.1" -c "$DIR"
-
-# Top-left: neovim
-tmux send-keys -t "$SESSION:1.1" "nvim ." Enter
-
-# Focus neovim
-tmux select-pane -t "$SESSION:1.1"
-
-echo -ne '\033]0;'"$TITLE"'\007'
-tmux attach -t "$SESSION"
+# Bottom-left: terminal
+kitty @ launch --location=hsplit --dont-take-focus --cwd "$DIR" --title terminal

--- a/prompt.zsh
+++ b/prompt.zsh
@@ -49,6 +49,7 @@ _precmd() {
     _cmd_duration=""
   fi
   _cmd_start=0
+  [[ -n "$KITTY_LISTEN_ON" ]] && kitty @ set-tab-title "$(basename $PWD)" 2>/dev/null
 }
 
 add-zsh-hook preexec _preexec


### PR DESCRIPTION
Remove tmux dependency and replace with kitty-native window management. Simpler layout (terminal + claude tabs), hints kitten, scrollback in nvim, auto tab title from cwd.