### PR TITLE
Scope zsh bin PATH and aws.zsh to work machine

### DIFF
--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -59,6 +59,7 @@ source ~/secrets.zsh
 # | PATH |
 # +------+
 
+export PATH="$HOME/.zsh/bin:$PATH"
 export PYENV_ROOT="$HOME/.pyenv"
 [[ -d $PYENV_ROOT/bin ]] && export PATH="$PYENV_ROOT/bin:$PATH"
 eval "$(pyenv init - zsh)"

--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -52,14 +52,18 @@ source ~/completion.zsh
 
 source ~/prompt.zsh
 source ~/aliases.zsh
+{{ if eq .machine "work" -}}
 source ~/aws.zsh
+{{ end -}}
 source ~/secrets.zsh
 
 # +------+
 # | PATH |
 # +------+
 
+{{ if eq .machine "work" -}}
 export PATH="$HOME/.zsh/bin:$PATH"
+{{ end -}}
 export PYENV_ROOT="$HOME/.pyenv"
 [[ -d $PYENV_ROOT/bin ]] && export PATH="$PYENV_ROOT/bin:$PATH"
 eval "$(pyenv init - zsh)"


### PR DESCRIPTION
Adds ~/.zsh/bin to PATH for aws-sso-switch and other local scripts, scoped to work machine only along with aws.zsh.