### PR TITLE
Flag terminal tab when agent is waiting for input

### DIFF
--- a/dot_claude/settings.json
+++ b/dot_claude/settings.json
@@ -26,6 +26,9 @@
       "Bash(sed *)",
       "Bash(grep *)",
       "Bash(find *)",
+      "Bash(grep:*)",
+      "Bash(find:*)",
+      "Bash(rg:*)",
       "Bash(echo *)",
       "Bash(less *)",
       "Bash(more *)",
@@ -38,16 +41,126 @@
       "Bash(open *)",
       "Bash(pbcopy)",
       "Bash(pbpaste)",
-      "Bash(sleep *)"
+      "Bash(sleep *)",
+      "Bash(git -C *)",
+      "Bash(git push *)",
+      "Bash(git pull *)",
+      "Bash(git worktree *)",
+      "Bash(git mv *)",
+      "Bash(gh pr *)",
+      "Bash(gh run *)",
+      "Bash(gh api *)",
+      "Bash(gh repo *)",
+      "Bash(gh release *)",
+      "Bash(kubectl get *)",
+      "Bash(kubectl logs *)",
+      "Bash(kubectl describe *)",
+      "Bash(kubectl rollout *)",
+      "Bash(kubectl top *)",
+      "Bash(kubectl wait *)",
+      "Bash(kubectl apply *)",
+      "Bash(kubectl run *)",
+      "Bash(kubectl drain *)",
+      "Bash(kubectl uncordon *)",
+      "Bash(kubectl cordon *)",
+      "Bash(dig *)",
+      "Bash(nslookup *)",
+      "Bash(helm list *)",
+      "Bash(helm search *)",
+      "Bash(helm show *)",
+      "Bash(helm template *)",
+      "Bash(helm repo *)"
     ]
   },
-  "model": "sonnet",
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/rules-hygiene.sh"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/block-secret-dumps.py"
+          },
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/git-safety.py"
+          }
+        ]
+      },
+      {
+        "matcher": "ExitPlanMode",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/plan-review-gate.py"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/redact-secrets.py"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.local/bin/agent-tab-status waiting claude"
+          }
+        ]
+      }
+    ],
+    "Notification": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.local/bin/agent-tab-status waiting claude"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.local/bin/agent-tab-status busy claude"
+          }
+        ]
+      }
+    ]
+  },
   "statusLine": {
     "type": "command",
     "command": "~/.claude/statusline.sh"
   },
   "enabledPlugins": {
     "rust-analyzer-lsp@claude-plugins-official": true,
-    "typescript-lsp@claude-plugins-official": true
-  }
+    "typescript-lsp@claude-plugins-official": true,
+    "swift-lsp@claude-plugins-official": true,
+    "context7@claude-plugins-official": true,
+    "semgrep@claude-plugins-official": false
+  },
+  "effortLevel": "high",
+  "skipAutoPermissionPrompt": true
 }

--- a/dot_config/ghostty/config
+++ b/dot_config/ghostty/config
@@ -1,0 +1,138 @@
+# =============================================================================
+# Ghostty config — translated from kitty.conf (Ayu Dark, Hack)
+# View all options + docs:  ghostty +show-config --default --docs
+# Reload in-app:            cmd+shift+,
+# =============================================================================
+
+# Ghostty sets TERM=xterm-ghostty by default. Override to match old setup.
+# (xterm-ghostty is better, but remote hosts need its terminfo installed.)
+term = xterm-256color
+
+# =============================================================================
+# Font
+# =============================================================================
+font-family = Hack
+font-family-bold = Hack Bold
+font-family-italic = Hack Italic
+font-family-bold-italic = Hack Bold Italic
+font-size = 12
+
+# kitty adjust_line_height/column_width 0  →  no adjustment (defaults)
+# adjust-cell-height = 0
+# adjust-cell-width = 0
+
+# =============================================================================
+# Cursor
+# =============================================================================
+cursor-style = block
+cursor-style-blink = false
+
+# =============================================================================
+# Scrollback (ghostty measures in BYTES, not lines; ~10MB default)
+# =============================================================================
+scrollback-limit = 10000000
+
+# =============================================================================
+# Mouse / selection
+# =============================================================================
+copy-on-select = true
+
+# =============================================================================
+# Window
+# =============================================================================
+window-padding-x = 12
+window-padding-y = 12
+background-opacity = 0.82
+window-width = 220
+window-height = 50
+window-save-state = always
+
+# macOS: use Option as Alt (shell word-jump shortcuts)
+macos-option-as-alt = true
+
+# =============================================================================
+# Bell  (replaces kitty's gold tab-recolor for "agent waiting on you")
+# =============================================================================
+# kitty had enable_audio_bell=no, so no sound. The agent-tab-status hook rings
+# the bell when Claude is waiting; these features turn that into a dock bounce
+# + tab attention/title marker instead of a beep.
+#   attention = bounce dock icon until Ghostty is focused
+#   title     = mark the tab title on bell
+bell-features = attention,title
+
+# =============================================================================
+# Theme — Ayu Dark
+# =============================================================================
+foreground = #b3b1ad
+background = #0a0e14
+selection-foreground = #b3b1ad
+selection-background = #273747
+
+cursor-color = #e6b450
+cursor-text = #0a0e14
+
+# 16-color palette
+palette = 0=#01060e
+palette = 1=#ea6c73
+palette = 2=#91b362
+palette = 3=#f9af4f
+palette = 4=#53bdfa
+palette = 5=#fae994
+palette = 6=#90e1c6
+palette = 7=#c7c7c7
+palette = 8=#686868
+palette = 9=#f07178
+palette = 10=#c2d94c
+palette = 11=#ffb454
+palette = 12=#59c2ff
+palette = 13=#ffee99
+palette = 14=#95e6cb
+palette = 15=#ffffff
+
+# =============================================================================
+# Key bindings
+# =============================================================================
+# Tabs (new_tab inherits cwd automatically in ghostty)
+keybind = cmd+t=new_tab
+keybind = cmd+w=close_surface
+keybind = cmd+]=next_tab
+keybind = cmd+[=previous_tab
+keybind = cmd+1=goto_tab:1
+keybind = cmd+2=goto_tab:2
+keybind = cmd+3=goto_tab:3
+keybind = cmd+4=goto_tab:4
+keybind = cmd+5=goto_tab:5
+keybind = cmd+6=goto_tab:6
+keybind = cmd+7=goto_tab:7
+keybind = cmd+8=goto_tab:8
+keybind = cmd+9=goto_tab:9
+
+# Splits
+keybind = cmd+d=new_split:right
+keybind = cmd+shift+d=new_split:down
+keybind = cmd+shift+]=goto_split:next
+keybind = cmd+shift+[=goto_split:previous
+
+# Pane navigation (ctrl+h/j/k/l — matches neovim splits)
+keybind = ctrl+h=goto_split:left
+keybind = ctrl+j=goto_split:down
+keybind = ctrl+k=goto_split:up
+keybind = ctrl+l=goto_split:right
+
+# Pane resize
+keybind = ctrl+shift+h=resize_split:left,30
+keybind = ctrl+shift+j=resize_split:down,30
+keybind = ctrl+shift+k=resize_split:up,30
+keybind = ctrl+shift+l=resize_split:right,30
+
+# Zoom toggle (like tmux prefix+z)
+keybind = cmd+shift+z=toggle_split_zoom
+
+# Font size
+keybind = cmd+equal=increase_font_size:1
+keybind = cmd+minus=decrease_font_size:1
+keybind = cmd+zero=reset_font_size
+
+# Scrollback
+keybind = cmd+k=scroll_page_up
+keybind = cmd+shift+k=clear_screen

--- a/dot_cursor/hooks.json.tmpl
+++ b/dot_cursor/hooks.json.tmpl
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "hooks": {
+    "stop": [
+      { "command": "{{ .chezmoi.homeDir }}/.local/bin/agent-tab-status waiting cursor" }
+    ],
+    "beforeSubmitPrompt": [
+      { "command": "{{ .chezmoi.homeDir }}/.local/bin/agent-tab-status busy cursor" }
+    ]
+  }
+}

--- a/dot_local/bin/executable_agent-tab-status
+++ b/dot_local/bin/executable_agent-tab-status
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# agent-tab-status — flag the terminal tab when an AI coding agent (Claude Code,
+# Cursor CLI, …) is waiting on you vs. busy working. Wired up from each agent's
+# hooks. In kitty it targets the exact window and recolors the tab; in any other
+# terminal it falls back to an OSC title + bell written to the controlling tty.
+#
+# Usage: agent-tab-status <waiting|busy> [agent-name]
+
+state="$1"
+agent="${2:-agent}"
+
+# Hooks run with cwd at the project root; Cursor also exports CURSOR_PROJECT_DIR.
+dir=$(basename "${CURSOR_PROJECT_DIR:-$PWD}")
+
+if [[ "$state" == waiting ]]; then
+  title="⏳ ${agent} [${dir}]"
+else
+  title="${agent} [${dir}]"
+fi
+
+if [[ -n "$KITTY_LISTEN_ON" ]]; then
+  match=()
+  [[ -n "$KITTY_WINDOW_ID" ]] && match=(-m "window_id:$KITTY_WINDOW_ID")
+  kitty @ set-tab-title "${match[@]}" "$title" 2>/dev/null
+  if [[ "$state" == waiting ]]; then
+    kitty @ set-tab-color "${match[@]}" \
+      active_bg='#e6b450' active_fg='#0b0e14' \
+      inactive_bg='#e6b450' inactive_fg='#0b0e14' 2>/dev/null
+  else
+    kitty @ set-tab-color "${match[@]}" \
+      active_bg=NONE active_fg=NONE inactive_bg=NONE inactive_fg=NONE 2>/dev/null
+  fi
+else
+  # OSC 2 sets the tab/window title in essentially any terminal.
+  printf '\033]2;%s\007' "$title" > /dev/tty 2>/dev/null
+  # Bell makes an unfocused tab light up where we can't recolor it.
+  [[ "$state" == waiting ]] && printf '\a' > /dev/tty 2>/dev/null
+fi
+
+exit 0

--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -71,6 +71,12 @@ eval "$(pyenv init - --no-rehash zsh)"
 export PATH="${HOMEBREW_PREFIX}/opt/openssl/bin:$PATH"
 {{ end -}}
 {{ if eq .machine "home" -}}
+JAVA_HOME=$(/usr/libexec/java_home 2>/dev/null) && export JAVA_HOME
+export ANDROID_HOME="$HOME/Library/Android/sdk"
+_ndk=$(ls -1 "$ANDROID_HOME/ndk" 2>/dev/null | sort -V | tail -1)
+[[ -n "$_ndk" ]] && export NDK_HOME="$ANDROID_HOME/ndk/$_ndk"
+unset _ndk
+export PATH="$ANDROID_HOME/platform-tools:$PATH"
 export PATH="{{ .chezmoi.homeDir }}/.deno/bin:$PATH"
 export PATH="/usr/local/opt/tcl-tk/bin:$PATH"
 {{ end -}}

--- a/prompt.zsh
+++ b/prompt.zsh
@@ -54,6 +54,8 @@ _precmd() {
   fi
   _cmd_start=0
   _kitty_title zsh
+  # Clear any leftover tab color from an agent (claude/cursor) that left it "waiting".
+  [[ -n "$KITTY_LISTEN_ON" ]] && kitty @ set-tab-color active_bg=NONE active_fg=NONE inactive_bg=NONE inactive_fg=NONE 2>/dev/null
 }
 
 add-zsh-hook preexec _preexec


### PR DESCRIPTION
Adds agent-tab-status, a shared script wired into Claude Code and Cursor CLI hooks that flags the terminal tab when the agent finishes its turn or needs input, and resets when a new prompt is submitted. In kitty it sets the tab title and yellow color targeting the specific window; in any other terminal it falls back to an OSC title plus bell. Also tracks the Ghostty config in chezmoi (bell-features drive the indicator there), clears leftover tab color on return to the shell via prompt.zsh, syncs the live Claude settings.json into the repo, and adds Java/Android SDK env on the home machine.